### PR TITLE
[MV-137] Screencast and tracks refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ When you have the participants all that's left is to render their video tracks. 
 ```ts
 {
   participant.videoTracks.map((track) => (
-    <VideoRendererView participantId={track.id} />
+    <VideoRendererView trackId={track.id} />
   ));
 }
 ```

--- a/README.md
+++ b/README.md
@@ -228,12 +228,12 @@ If you have the connection set up, then use `useParticipants()` hook to track th
 const participants = useParticipants();
 ```
 
-When you have the participants all that's left is to render them. Use `<VideoRendererView />` component like this:
+When you have the participants all that's left is to render their video tracks. Use `<VideoRendererView />` component like this:
 
 ```ts
 {
-  participants.map((participant) => (
-    <VideoRendererView participantId={participant.id} />
+  participant.videoTracks.map((track) => (
+    <VideoRendererView participantId={track.id} />
   ));
 }
 ```

--- a/android/src/main/java/com/reactnativemembrane/Participant.kt
+++ b/android/src/main/java/com/reactnativemembrane/Participant.kt
@@ -7,9 +7,28 @@ import org.membraneframework.rtc.utils.Metadata
 data class Participant(
   val id: String,
   val metadata: Metadata,
-  val videoTrack: VideoTrack? = null,
-  val videoTrackMetadata: Metadata? = null,
-  val audioTrack: AudioTrack? = null,
-  val audioTrackMetadata: Metadata? = null,
-  val isScreencast: Boolean = false,
-)
+  val videoTracks: HashMap<String, VideoTrack> = hashMapOf(),
+  val audioTracks: HashMap<String, AudioTrack> = hashMapOf(),
+  val tracksMetadata: HashMap<String, Metadata> = hashMapOf()
+) {
+
+  fun addOrUpdateTrack(videoTrack: VideoTrack, metadata: Metadata) {
+    this.tracksMetadata[videoTrack.id()] = metadata
+    this.videoTracks[videoTrack.id()] = videoTrack
+  }
+
+  fun addOrUpdateTrack(audioTrack: AudioTrack, metadata: Metadata) {
+    this.tracksMetadata[audioTrack.id()] = metadata
+    this.audioTracks[audioTrack.id()] = audioTrack
+  }
+
+  fun removeTrack(videoTrack: VideoTrack) {
+    this.tracksMetadata.remove(videoTrack.id())
+    this.videoTracks.remove(videoTrack.id())
+  }
+
+  fun removeTrack(audioTrack: AudioTrack) {
+    this.tracksMetadata.remove(audioTrack.id())
+    this.audioTracks.remove(audioTrack.id())
+  }
+}

--- a/android/src/main/java/com/reactnativemembrane/VideoRendererView.kt
+++ b/android/src/main/java/com/reactnativemembrane/VideoRendererView.kt
@@ -11,7 +11,7 @@ class VideoRendererWrapper(context: Context) {
   var view: VideoTextureViewRenderer = VideoTextureViewRenderer(context)
   var isInitialized = false
   var activeVideoTrack: VideoTrack? = null
-  var participantId: String? = null
+  var trackId: String? = null
 
   fun setupTrack(videoTrack: VideoTrack) {
     if (activeVideoTrack == videoTrack) return
@@ -23,18 +23,18 @@ class VideoRendererWrapper(context: Context) {
 
   fun update() {
     CoroutineScope(Dispatchers.Main).launch {
-      val participant = MembraneModule.participants[participantId] ?: return@launch
-      if(participant.videoTrack == null) return@launch;
+      val participant = MembraneModule.participants.values.firstOrNull { it.videoTracks[trackId] != null }
+      val videoTrack = participant?.videoTracks?.get(trackId) ?: return@launch
       if(!isInitialized) {
         isInitialized = true
-        view.init(participant.videoTrack.eglContext, null)
+        view.init(videoTrack.eglContext, null)
       }
-      setupTrack(participant.videoTrack)
+      setupTrack(videoTrack)
     }
   }
 
-  fun init(participantId: String) {
-    this.participantId = participantId
+  fun init(trackId: String) {
+    this.trackId = trackId
     update()
   }
 

--- a/android/src/main/java/com/reactnativemembrane/VideoRendererViewManager.kt
+++ b/android/src/main/java/com/reactnativemembrane/VideoRendererViewManager.kt
@@ -28,9 +28,9 @@ class VideoRendererViewManager : SimpleViewManager<View>() {
     viewsWrappers.remove(view)
   }
 
-  @ReactProp(name = "participantId")
-  fun setParticipantId(view: VideoTextureViewRenderer, participantId: String) {
-    viewsWrappers[view]?.init(participantId)
+  @ReactProp(name = "trackId")
+  fun setParticipantId(view: VideoTextureViewRenderer, trackId: String) {
+    viewsWrappers[view]?.init(trackId)
   }
 
   @ReactProp(name = "videoLayout")

--- a/example/src/Controls.tsx
+++ b/example/src/Controls.tsx
@@ -61,7 +61,11 @@ export const Controls = ({ disconnect }: { disconnect: () => void }) => {
       <Pressable
         onPress={() =>
           toggleScreencast({
-            screencastMetadata: { displayName: 'presenting' },
+            screencastMetadata: {
+              displayName: 'presenting',
+              type: 'screensharing',
+              active: 'true',
+            },
             simulcastConfig: {
               enabled: true,
               activeEncodings: ['l', 'm', 'h'],

--- a/example/src/Settings.tsx
+++ b/example/src/Settings.tsx
@@ -69,7 +69,7 @@ export const Settings = ({
       </View>
     );
   }
-  if (track.metadata.type === 'screencasting') {
+  if (track.metadata.type === 'screensharing') {
     return (
       <View style={styles.container}>
         <Text>Encodings to send:</Text>

--- a/example/src/Settings.tsx
+++ b/example/src/Settings.tsx
@@ -1,8 +1,10 @@
 import {
   Participant,
+  Track,
   useSimulcast,
   useBandwidthLimit,
   useScreencast,
+  TrackEncoding,
 } from '@membraneframework/react-native-membrane-webrtc';
 import React, { useState } from 'react';
 import {
@@ -14,12 +16,14 @@ import {
   TouchableOpacity,
 } from 'react-native';
 
-const allEncodings = ['h', 'm', 'l'];
+const allEncodings: TrackEncoding[] = ['h', 'm', 'l'];
 
 export const Settings = ({
   participant: { type, id },
+  track,
 }: {
   participant: Participant;
+  track: Track;
 }) => {
   const {
     setTargetTrackEncoding,
@@ -65,7 +69,7 @@ export const Settings = ({
       </View>
     );
   }
-  if (type === 'LocalScreencasting') {
+  if (track.metadata.type === 'screencasting') {
     return (
       <View style={styles.container}>
         <Text>Encodings to send:</Text>
@@ -102,7 +106,7 @@ export const Settings = ({
       <Text>Encoding to receive:</Text>
       <View style={styles.row}>
         {allEncodings.map((e) => (
-          <TouchableOpacity onPress={() => setTargetTrackEncoding(id, e)}>
+          <TouchableOpacity onPress={() => setTargetTrackEncoding(track.id, e)}>
             <Text style={styles.button}>{e}</Text>
           </TouchableOpacity>
         ))}

--- a/ios/Membrane.m
+++ b/ios/Membrane.m
@@ -25,7 +25,7 @@ RCT_EXTERN_METHOD(updateScreencastTrackMetadata:(NSDictionary)metadata withResol
 RCT_EXTERN_METHOD(toggleScreencastTrackEncoding:(NSString)encoding withResolver:(RCTPromiseResolveBlock)resolve withRejecter:(RCTPromiseRejectBlock)reject)
 RCT_EXTERN_METHOD(setScreencastTrackBandwidth:(nonnull NSNumber)bandwidth withResolver:(RCTPromiseResolveBlock)resolve withRejecter:(RCTPromiseRejectBlock)reject)
 RCT_EXTERN_METHOD(setScreencastTrackEncodingBandwidth:(NSString)encoding withBandwidth:(nonnull NSNumber)bandwidth withResolver:(RCTPromiseResolveBlock)resolve withRejecter:(RCTPromiseRejectBlock)reject)
-RCT_EXTERN_METHOD(setTargetTrackEncoding:(NSString)peerId withEncoding:(NSString)encoding withResolver:(RCTPromiseResolveBlock)resolve withRejecter:(RCTPromiseRejectBlock)reject)
+RCT_EXTERN_METHOD(setTargetTrackEncoding:(NSString)trackId withEncoding:(NSString)encoding withResolver:(RCTPromiseResolveBlock)resolve withRejecter:(RCTPromiseRejectBlock)reject)
 RCT_EXTERN_METHOD(toggleVideoTrackEncoding:(NSString)encoding withResolver:(RCTPromiseResolveBlock)resolve withRejecter:(RCTPromiseRejectBlock)reject)
 RCT_EXTERN_METHOD(setVideoTrackEncodingBandwidth:(NSString)encoding withBandwidth:(nonnull NSNumber)bandwidth withResolver:(RCTPromiseResolveBlock)resolve withRejecter:(RCTPromiseRejectBlock)reject)
 RCT_EXTERN_METHOD(setVideoTrackBandwidth:(nonnull NSNumber)bandwidth withResolver:(RCTPromiseResolveBlock)resolve withRejecter:(RCTPromiseRejectBlock)reject)

--- a/ios/Membrane.swift
+++ b/ios/Membrane.swift
@@ -236,7 +236,7 @@ class Membrane: RCTEventEmitter, MembraneRTCDelegate {
       }
       
       let localParticipant = MembraneRoom.sharedInstance.participants[localParticipantId]
-      MembraneRoom.sharedInstance.participants[localParticipantId] = localParticipant?.removeVideoTrack(trackId: screencastTrackId)
+      MembraneRoom.sharedInstance.participants[localParticipantId] = localParticipant?.removeTrack(trackId: screencastTrackId)
       room.removeTrack(trackId: screencastTrackId)
       self.localScreencastTrack = nil
       
@@ -600,10 +600,10 @@ class Membrane: RCTEventEmitter, MembraneRTCDelegate {
       return
     }
     if let audioTrack = ctx.track as? RemoteAudioTrack {
-      participant = participant.removeAudioTrack(trackId: audioTrack.track.trackId)
+      participant = participant.removeTrack(trackId: audioTrack.track.trackId)
     }
     if let videoTrack = ctx.track as? RemoteVideoTrack {
-      participant = participant.removeVideoTrack(trackId: videoTrack.track.trackId)
+      participant = participant.removeTrack(trackId: videoTrack.track.trackId)
     }
     globalToLocalTrackId.removeValue(forKey: ctx.trackId)
     MembraneRoom.sharedInstance.participants[ctx.peer.id] = participant

--- a/ios/Membrane.swift
+++ b/ios/Membrane.swift
@@ -57,47 +57,6 @@ public extension String {
   }
 }
 
-struct Participant {
-  let id: String
-  let metadata: Metadata
-  let order: Int
-  var videoTrackMetadata: Metadata?
-  var audioTrackMetadata: Metadata?
-  
-  static var participantCounter = 0
-  
-  init(id: String, metadata: Metadata, videoTrackMetadata: Metadata? = nil,
-       audioTrackMetadata: Metadata? = nil) {
-    self.id = id
-    self.metadata = metadata
-    self.order = Participant.participantCounter
-    self.videoTrackMetadata = videoTrackMetadata
-    self.audioTrackMetadata = audioTrackMetadata
-    Participant.participantCounter += 1
-  }
-}
-
-class ParticipantVideo: Identifiable, ObservableObject {
-  let id: String
-  let participant: Participant
-  
-  @Published var videoTrack: VideoTrack
-  var mirror: Bool
-  
-  init(id: String, participant: Participant, videoTrack: VideoTrack, mirror: Bool = false) {
-    self.id = id
-    self.participant = participant
-    self.videoTrack = videoTrack
-    self.mirror = mirror
-  }
-}
-
-extension LocalAudioTrack{
-    public func trackId() -> String {
-        return track.trackId
-    }
-}
-
 @objc(Membrane)
 class Membrane: RCTEventEmitter, MembraneRTCDelegate {
   var localVideoTrack: LocalVideoTrack?
@@ -114,8 +73,6 @@ class Membrane: RCTEventEmitter, MembraneRTCDelegate {
   
   
   var localParticipantId: String?
-  var localScreensharingVideoId: String?
-  var localScreensharingParticipantId: String?
   var isFrontCamera: Bool = true
   
   var room: MembraneRTC? = nil;
@@ -129,6 +86,11 @@ class Membrane: RCTEventEmitter, MembraneRTCDelegate {
   var videoBandwidthLimit: TrackBandwidthLimit = .BandwidthLimit(0)
   var screenshareSimulcastConfig: SimulcastConfig = SimulcastConfig()
   var screenshareBandwidthLimit: TrackBandwidthLimit = .BandwidthLimit(0)
+  var globalToLocalTrackId: [String:String] = [:]
+  
+  private func getGlobalTrackId(localTrackId: String) -> String? {
+    return globalToLocalTrackId.filter { $0.value == localTrackId }.first?.key
+  }
   
   @objc static override func requiresMainQueueSetup() -> Bool {
       return false
@@ -194,7 +156,6 @@ class Membrane: RCTEventEmitter, MembraneRTCDelegate {
     room?.disconnect()
     room = nil
     MembraneRoom.sharedInstance.participants = [:]
-    MembraneRoom.sharedInstance.participantVideos = []
     resolve(nil)
   }
   
@@ -245,8 +206,7 @@ class Membrane: RCTEventEmitter, MembraneRTCDelegate {
       simulcastConfig: screenshareSimulcastConfig
     )
     
-    var screencastMetadata = (screencastOptions["screencastMetadata"] as? NSDictionary)?.toMetadata() ?? Metadata()
-    screencastMetadata["type"] = "screensharing"
+    let screencastMetadata = (screencastOptions["screencastMetadata"] as? NSDictionary)?.toMetadata() ?? Metadata()
     
       self.localScreencastTrack = room.createScreencastTrack(appGroup: appGroupName, videoParameters: videoParameters, metadata: screencastMetadata, onStart: { [weak self] screencastTrack in
       guard let self = self else {
@@ -256,33 +216,29 @@ class Membrane: RCTEventEmitter, MembraneRTCDelegate {
         return
       }
       
-      self.localScreensharingVideoId = UUID().uuidString
-      self.localScreensharingParticipantId = UUID().uuidString
-      guard let localScreensharingParticipantId = self.localScreensharingParticipantId else { return }
-      let localScreensharingParticipant = Participant(id: localScreensharingParticipantId, metadata: screencastMetadata)
-      MembraneRoom.sharedInstance.participants[localScreensharingParticipantId] = localScreensharingParticipant
-    
-      let localParticipantScreensharing = ParticipantVideo(
-        id: self.localScreensharingVideoId!,
-        participant: localScreensharingParticipant,
-        videoTrack: screencastTrack
-      )
-      
-      self.add(video: localParticipantScreensharing)
+      guard let localParticipantId = self.localParticipantId, let screencastTrackId = self.localScreencastTrack?.trackId() else {
+         return
+      }
+        
+      MembraneRoom.sharedInstance.participants[localParticipantId]?.videoTracks[screencastTrackId] = screencastTrack
+      MembraneRoom.sharedInstance.participants[localParticipantId]?.tracksMetadata[screencastTrackId] = screencastMetadata
+        
       self.isScreensharingEnabled = true
       self.emitEvent(name: "IsScreencastOn", data: true)
       self.emitParticipants()
     }, onStop: { [weak self] in
-      guard let self = self,
-            let localScreensharingId = self.localScreensharingVideoId,
-            let video = self.findParticipantVideo(id: localScreensharingId),
-            let localScreensharingParticipantId = self.localScreensharingParticipantId
-      else {
+      guard let self = self else {
         return
       }
       
-      self.remove(video: video)
-      MembraneRoom.sharedInstance.participants.removeValue(forKey: localScreensharingParticipantId)
+      guard let localParticipantId = self.localParticipantId, let screencastTrackId = self.localScreencastTrack?.trackId() else {
+        return
+      }
+      
+      let localParticipant = MembraneRoom.sharedInstance.participants[localParticipantId]
+      MembraneRoom.sharedInstance.participants[localParticipantId] = localParticipant?.removeVideoTrack(trackId: screencastTrackId)
+      room.removeTrack(trackId: screencastTrackId)
+      self.localScreencastTrack = nil
       
       self.isScreensharingEnabled = false
       self.emitEvent(name: "IsScreencastOn", data: false)
@@ -299,18 +255,27 @@ class Membrane: RCTEventEmitter, MembraneRTCDelegate {
       (p) -> Dictionary in
       var participantType = ""
       if (p.id == localParticipantId) {
-          participantType = "Local"
-      } else if (p.id == localScreensharingParticipantId) {
-        participantType = "LocalScreencasting"
+        participantType = "Local"
       } else {
         participantType = "Remote"
       }
+      
+      let videoTracks = p.videoTracks.keys.map { trackId in [
+        "id": trackId,
+        "type": "Video",
+        "metadata": p.tracksMetadata[trackId]?.toDict() ?? [:]
+      ]}
+      
+      let audioTracks = p.audioTracks.keys.map { trackId in [
+        "id": trackId,
+        "type": "Audio",
+        "metadata": p.tracksMetadata[trackId]?.toDict() ?? [:]
+      ]}
         
       return [
         "id": p.id,
         "metadata": p.metadata.toDict(),
-        "videoTrackMetadata": p.videoTrackMetadata?.toDict() ?? [:],
-        "audioTrackMetadata": p.audioTrackMetadata?.toDict() ?? [:],
+        "tracks": videoTracks + audioTracks,
         "type": participantType
       ]
     }]
@@ -360,17 +325,6 @@ class Membrane: RCTEventEmitter, MembraneRTCDelegate {
 
     cameraTrack.switchCamera()
     isFrontCamera = !isFrontCamera
-    
-    guard let id = localParticipantId,
-          let localVideo = findParticipantVideo(id: id) else {
-              return
-    }
-    
-    let localIsFrontCamera = isFrontCamera
-    // HACK: there is a delay when we set the mirror and the camer actually switches
-    DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
-        localVideo.mirror = localIsFrontCamera
-    }
     resolve(nil)
   }
     
@@ -379,40 +333,44 @@ class Membrane: RCTEventEmitter, MembraneRTCDelegate {
         room?.updatePeerMetadata(peerMetadata: metadata.toMetadata())
         resolve(nil)
     }
+  
+  func updateTrackMetadata(trackId: String, metadata:NSDictionary) {
+    guard let room = room, let peerId = localParticipantId else {
+      return
+    }
+    
+    room.updateTrackMetadata(trackId: trackId, trackMetadata: metadata.toMetadata())
+    MembraneRoom.sharedInstance.participants[peerId]?.tracksMetadata[trackId] = metadata.toMetadata()
+    emitParticipants()
+  }
     
     @objc(updateVideoTrackMetadata:withResolver:withRejecter:)
     func updateVideoTrackMetadata(metadata:NSDictionary, resolve:RCTPromiseResolveBlock, reject:RCTPromiseRejectBlock) -> Void {
-        guard let room = room, let trackId = localVideoTrack?.trackId(), let peerId = localParticipantId else {
+        guard let trackId = localVideoTrack?.trackId() else {
             return
         }
 
-        room.updateTrackMetadata(trackId: trackId, trackMetadata: metadata.toMetadata())
-        MembraneRoom.sharedInstance.participants[peerId]?.videoTrackMetadata = metadata.toMetadata()
-        emitParticipants()
+        updateTrackMetadata(trackId: trackId, metadata: metadata)
         resolve(nil)
     }
     
     @objc(updateAudioTrackMetadata:withResolver:withRejecter:)
     func updateAudioTrackMetadata(metadata:NSDictionary, resolve:RCTPromiseResolveBlock, reject:RCTPromiseRejectBlock) -> Void {
-        guard let room = room, let trackId = localAudioTrack?.trackId(), let peerId = localParticipantId else {
+        guard let trackId = localAudioTrack?.trackId() else {
             return
         }
 
-        room.updateTrackMetadata(trackId: trackId, trackMetadata: metadata.toMetadata())
-        MembraneRoom.sharedInstance.participants[peerId]?.audioTrackMetadata = metadata.toMetadata()
-        emitParticipants()
+      updateTrackMetadata(trackId: trackId, metadata: metadata)
         resolve(nil)
     }
     
     @objc(updateScreencastTrackMetadata:withResolver:withRejecter:)
     func updateScreencastTrackMetadata(metadata:NSDictionary, resolve:RCTPromiseResolveBlock, reject:RCTPromiseRejectBlock) -> Void {
-        guard let room = room, let trackId = localScreencastTrack?.trackId() else {
+        guard let trackId = localScreencastTrack?.trackId() else {
             return
         }
 
-        room.updateTrackMetadata(trackId: trackId, trackMetadata: metadata.toMetadata())
-        MembraneRoom.sharedInstance.participants[trackId]?.audioTrackMetadata = metadata.toMetadata()
-        emitParticipants()
+      updateTrackMetadata(trackId: trackId, metadata: metadata)
         resolve(nil)
     }
   
@@ -465,15 +423,17 @@ class Membrane: RCTEventEmitter, MembraneRTCDelegate {
   }
   
   @objc(setTargetTrackEncoding:withEncoding:withResolver:withRejecter:)
-  func setTargetTrackEncoding(peerId: NSString, encoding: NSString, resolve:RCTPromiseResolveBlock, reject:RCTPromiseRejectBlock) -> Void {
+  func setTargetTrackEncoding(trackId: NSString, encoding: NSString, resolve:RCTPromiseResolveBlock, reject:RCTPromiseRejectBlock) -> Void {
     guard
       let room = room,
-      let trackId = MembraneRoom.sharedInstance.participantVideos.first(where: { $0.participant.id == peerId as String })?.id,
+      let videoTrack = MembraneRoom.sharedInstance.getVideoTrackById(trackId: trackId as String),
+      let trackId = (videoTrack as? RemoteVideoTrack)?.track.trackId ?? (videoTrack as? LocalVideoTrack)?.trackId(),
+      let globalTrackId = getGlobalTrackId(localTrackId: trackId as String),
       let trackEncoding = (encoding as String).toTrackEncoding()
     else {
       return
     }
-    room.setTargetTrackEncoding(trackId: trackId, encoding: trackEncoding)
+    room.setTargetTrackEncoding(trackId: globalTrackId, encoding: trackEncoding)
     resolve(nil)
   }
   
@@ -523,29 +483,6 @@ class Membrane: RCTEventEmitter, MembraneRTCDelegate {
     emitEvent(name: "ParticipantsUpdate", data: getParticipantsForRN())
   }
   
-  func findParticipantVideo(id: String) -> ParticipantVideo? {
-    return MembraneRoom.sharedInstance.participantVideos.first(where: { $0.id == id })
-  }
-  
-  func add(video: ParticipantVideo) {
-    guard findParticipantVideo(id: video.id) == nil else {
-      print("RoomController tried to add already existing ParticipantVideo")
-      return
-    }
-    
-    MembraneRoom.sharedInstance.participantVideos.append(video)
-    emitParticipants()
-  }
-  
-  func remove(video: ParticipantVideo) {
-    guard let idx = MembraneRoom.sharedInstance.participantVideos.firstIndex(where: { $0.id == video.id }) else {
-      return
-    }
-    
-    MembraneRoom.sharedInstance.participantVideos.remove(at: idx)
-    emitParticipants()
-  }
-  
   func onConnected() {
     guard let room = room else {
       return
@@ -583,8 +520,27 @@ class Membrane: RCTEventEmitter, MembraneRTCDelegate {
       simulcastConfig: self.videoSimulcastConfig
     )
     
+    let localParticipantId = UUID().uuidString
+    self.localParticipantId = localParticipantId
+    
     localVideoTrack = room.createVideoTrack(videoParameters: videoParameters, metadata: videoTrackMetadata)
     localAudioTrack = room.createAudioTrack(metadata: audioTrackMetadata)
+    
+    var localParticipant = Participant(
+      id: localParticipantId,
+      metadata: localUserMetadata)
+    
+    if let localVideoTrack = localVideoTrack {
+      localParticipant.videoTracks = [localVideoTrack.trackId(): localVideoTrack]
+      localParticipant.tracksMetadata[localVideoTrack.trackId()] = videoTrackMetadata
+    }
+    
+    if let localAudioTrack = localAudioTrack {
+      localParticipant.audioTracks = [localAudioTrack.trackId(): localAudioTrack]
+      localParticipant.tracksMetadata[localAudioTrack.trackId()] = audioTrackMetadata
+    }
+    
+    MembraneRoom.sharedInstance.participants[localParticipantId] = localParticipant
     
     if let connectResolve = connectResolve {
       connectResolve(nil)
@@ -592,25 +548,9 @@ class Membrane: RCTEventEmitter, MembraneRTCDelegate {
   }
   
   func onJoinSuccess(peerID: String, peersInRoom: [Peer]) {
-    localParticipantId = peerID
-    
-    let localParticipant = Participant(
-      id: peerID,
-      metadata: localUserMetadata,
-      videoTrackMetadata: videoTrackMetadata,
-      audioTrackMetadata: audioTrackMetadata
-    )
-    
-    let participants = peersInRoom.map { peer in
-      Participant(id: peer.id, metadata: peer.metadata)
+    peersInRoom.forEach { peer in
+      MembraneRoom.sharedInstance.participants[peer.id] = Participant(id: peer.id, metadata: peer.metadata)
     }
-    
-    MembraneRoom.sharedInstance.participants[localParticipant.id] = localParticipant
-    guard let videoTrack = self.localVideoTrack else {
-      fatalError("failed to setup local video")
-    }
-    add(video: ParticipantVideo(id: localParticipant.id, participant: localParticipant, videoTrack: videoTrack, mirror: self.isFrontCamera))
-    participants.forEach { participant in MembraneRoom.sharedInstance.participants[participant.id] = participant }
     
     emitParticipants()
     if let joinResolve = joinResolve {
@@ -628,48 +568,27 @@ class Membrane: RCTEventEmitter, MembraneRTCDelegate {
     joinReject = nil
   }
   
-  func onTrackReady(ctx: TrackContext) {
-    if ctx.track is AudioTrack {
-      MembraneRoom.sharedInstance.participants[ctx.peer.id]?.audioTrackMetadata = ctx.metadata
+  func updateOrAddTrack(ctx: TrackContext) {
+    guard var participant = MembraneRoom.sharedInstance.participants[ctx.peer.id] else {
       return
     }
-    
-    guard let participant = MembraneRoom.sharedInstance.participants[ctx.peer.id],
-          let videoTrack = ctx.track as? VideoTrack
-    else {
-      return
+    if let audioTrack = ctx.track as? RemoteAudioTrack {
+      globalToLocalTrackId[ctx.trackId] = (ctx.track as? RemoteAudioTrack)?.track.trackId
+      participant.audioTracks[audioTrack.track.trackId] = audioTrack
+      participant.tracksMetadata[audioTrack.track.trackId] = ctx.metadata
     }
     
-    // there can be a situation where we simply need to replace `videoTrack` for
-    // already existing video, happens when dynamically adding new local track
-    if let participantVideo = MembraneRoom.sharedInstance.participantVideos.first(where: { $0.id == ctx.trackId }) {
-      DispatchQueue.main.async {
-        participantVideo.videoTrack = videoTrack
-      }
-      
-      return
+    if let videoTrack = ctx.track as? RemoteVideoTrack {
+      globalToLocalTrackId[ctx.trackId] = (ctx.track as? RemoteVideoTrack)?.track.trackId
+      participant.videoTracks[videoTrack.track.trackId] = videoTrack
+      participant.tracksMetadata[videoTrack.track.trackId] = ctx.metadata
     }
-    
-    if ctx.metadata["type"] as? String == "screensharing" {
-      // add a fake screencasting participant
-      let screensharingParticipant = Participant(id: ctx.trackId, metadata: ctx.metadata, videoTrackMetadata: ctx.metadata)
-      MembraneRoom.sharedInstance.participants[screensharingParticipant.id] = screensharingParticipant
-      let video = ParticipantVideo(
-        id: ctx.trackId,
-        participant: screensharingParticipant,
-        videoTrack: videoTrack
-      )
-      add(video: video)
-    } else {
-      let video = ParticipantVideo(
-        id: ctx.trackId,
-        participant: participant,
-        videoTrack: videoTrack
-      )
-      add(video: video)
-      MembraneRoom.sharedInstance.participants[ctx.peer.id]?.videoTrackMetadata = ctx.metadata
-    }
+    MembraneRoom.sharedInstance.participants[ctx.peer.id] = participant
     emitParticipants()
+  }
+  
+  func onTrackReady(ctx: TrackContext) {
+    updateOrAddTrack(ctx: ctx)
   }
   
   func onTrackAdded(ctx: TrackContext) {
@@ -677,27 +596,22 @@ class Membrane: RCTEventEmitter, MembraneRTCDelegate {
   }
   
   func onTrackRemoved(ctx: TrackContext) {
-    if (ctx.metadata["type"] as? String == "screensharing") {
-      if let video = MembraneRoom.sharedInstance.participantVideos.first(where: { $0.id == ctx.trackId }) {
-        MembraneRoom.sharedInstance.participants.removeValue(forKey: video.participant.id)
-        remove(video: video)
-      }
+    guard var participant = MembraneRoom.sharedInstance.participants[ctx.peer.id] else {
+      return
     }
-    if let video = MembraneRoom.sharedInstance.participantVideos.first(where: { $0.id == ctx.trackId }) {
-      remove(video: video)
+    if let audioTrack = ctx.track as? RemoteAudioTrack {
+      participant = participant.removeAudioTrack(trackId: audioTrack.track.trackId)
     }
+    if let videoTrack = ctx.track as? RemoteVideoTrack {
+      participant = participant.removeVideoTrack(trackId: videoTrack.track.trackId)
+    }
+    globalToLocalTrackId.removeValue(forKey: ctx.trackId)
+    MembraneRoom.sharedInstance.participants[ctx.peer.id] = participant
     emitParticipants()
   }
   
   func onTrackUpdated(ctx: TrackContext) {
-    if ctx.track is AudioTrack {
-      MembraneRoom.sharedInstance.participants[ctx.peer.id]?.audioTrackMetadata = ctx.metadata
-    } else if (ctx.metadata["type"] as? String == "screensharing") {
-      MembraneRoom.sharedInstance.participants[ctx.trackId]?.videoTrackMetadata = ctx.metadata
-    } else {
-      MembraneRoom.sharedInstance.participants[ctx.peer.id]?.videoTrackMetadata = ctx.metadata
-    }
-    self.emitParticipants()
+    updateOrAddTrack(ctx: ctx)
   }
   
   func onPeerJoined(peer: Peer) {

--- a/ios/Membrane.xcodeproj/project.pbxproj
+++ b/ios/Membrane.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		44DE31EF2909C56B0032DFBC /* Participant.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44DE31EE2909C56B0032DFBC /* Participant.swift */; };
 		F4FF95D7245B92E800C19C63 /* Membrane.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4FF95D6245B92E800C19C63 /* Membrane.swift */; };
 /* End PBXBuildFile section */
 
@@ -24,6 +25,7 @@
 
 /* Begin PBXFileReference section */
 		134814201AA4EA6300B7C361 /* libMembrane.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libMembrane.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		44DE31EE2909C56B0032DFBC /* Participant.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Participant.swift; sourceTree = "<group>"; };
 		B3E7B5891CC2AC0600A0062D /* Membrane.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Membrane.m; sourceTree = "<group>"; };
 		F4FF95D5245B92E700C19C63 /* Membrane-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Membrane-Bridging-Header.h"; sourceTree = "<group>"; };
 		F4FF95D6245B92E800C19C63 /* Membrane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Membrane.swift; sourceTree = "<group>"; };
@@ -53,6 +55,7 @@
 			children = (
 				F4FF95D6245B92E800C19C63 /* Membrane.swift */,
 				B3E7B5891CC2AC0600A0062D /* Membrane.m */,
+				44DE31EE2909C56B0032DFBC /* Participant.swift */,
 				F4FF95D5245B92E700C19C63 /* Membrane-Bridging-Header.h */,
 				134814211AA4EA7D00B7C361 /* Products */,
 			);
@@ -116,6 +119,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				F4FF95D7245B92E800C19C63 /* Membrane.swift in Sources */,
+				44DE31EF2909C56B0032DFBC /* Participant.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/MembraneRoom.swift
+++ b/ios/MembraneRoom.swift
@@ -1,8 +1,13 @@
+import MembraneRTC
+
 class MembraneRoom: NSObject {
   static let sharedInstance = MembraneRoom()
   private override init() {}
   
-  var participants: [String: Participant] = [:]
-  @Published var participantVideos: [ParticipantVideo] = []
+  @Published var participants: [String:Participant] = [:]
   
+  func getVideoTrackById(trackId: String) -> VideoTrack? {
+    let videoTracks = participants.values.map { p in p.videoTracks.values }.joined()
+    return videoTracks.first(where: {($0 as? RemoteVideoTrack)?.track.trackId == trackId || ($0 as? LocalVideoTrack)?.trackId() == trackId})
+  }
 }

--- a/ios/Participant.swift
+++ b/ios/Participant.swift
@@ -26,15 +26,9 @@ struct Participant {
     Participant.participantCounter += 1
   }
   
-  func removeVideoTrack(trackId: String) -> Participant {
+  func removeTrack(trackId: String) -> Participant {
     var newParticipant = self
     newParticipant.videoTracks.removeValue(forKey: trackId)
-    newParticipant.tracksMetadata.removeValue(forKey: trackId)
-    return newParticipant
-  }
-  
-  func removeAudioTrack(trackId: String) -> Participant {
-    var newParticipant = self
     newParticipant.audioTracks.removeValue(forKey: trackId)
     newParticipant.tracksMetadata.removeValue(forKey: trackId)
     return newParticipant

--- a/ios/Participant.swift
+++ b/ios/Participant.swift
@@ -1,0 +1,42 @@
+import MembraneRTC
+
+struct Participant {
+  let id: String
+  let metadata: Metadata
+  let order: Int
+  var tracksMetadata: [String:Metadata]
+  var videoTracks: [String:VideoTrack]
+  var audioTracks: [String:AudioTrack]
+  
+  static var participantCounter = 0
+  
+  init(
+    id: String,
+    metadata: Metadata,
+    videoTracks: [String:VideoTrack] = [:],
+    audioTracks: [String:AudioTrack] = [:],
+    tracksMetadata: [String:Metadata] = [:]
+  ) {
+    self.id = id
+    self.metadata = metadata
+    self.order = Participant.participantCounter
+    self.videoTracks = videoTracks
+    self.audioTracks = audioTracks
+    self.tracksMetadata = tracksMetadata
+    Participant.participantCounter += 1
+  }
+  
+  func removeVideoTrack(trackId: String) -> Participant {
+    var newParticipant = self
+    newParticipant.videoTracks.removeValue(forKey: trackId)
+    newParticipant.tracksMetadata.removeValue(forKey: trackId)
+    return newParticipant
+  }
+  
+  func removeAudioTrack(trackId: String) -> Participant {
+    var newParticipant = self
+    newParticipant.audioTracks.removeValue(forKey: trackId)
+    newParticipant.tracksMetadata.removeValue(forKey: trackId)
+    return newParticipant
+  }
+}

--- a/ios/VideoRendererViewManager.m
+++ b/ios/VideoRendererViewManager.m
@@ -2,7 +2,7 @@
 
 @interface RCT_EXTERN_MODULE(VideoRendererViewManager, RCTViewManager)
 
-RCT_EXPORT_VIEW_PROPERTY(participantId, NSString)
+RCT_EXPORT_VIEW_PROPERTY(trackId, NSString)
 RCT_EXPORT_VIEW_PROPERTY(videoLayout, NSString)
 
 @end

--- a/ios/VideoRendererViewManager.swift
+++ b/ios/VideoRendererViewManager.swift
@@ -15,14 +15,14 @@ class VideoRendererViewManager: RCTViewManager {
 
 class VideoRendererView : UIView {
   var videoView: VideoView? = nil
-  var cancellableParticipantVideos: Cancellable? = nil
+  var cancellableParticipants: Cancellable? = nil
   
   override init(frame: CGRect) {
     super.init(frame: frame)
     videoView = VideoView()
     videoView?.autoresizingMask = [.flexibleWidth, .flexibleHeight]
     addSubview(videoView!)
-    cancellableParticipantVideos = MembraneRoom.sharedInstance.$participantVideos
+    cancellableParticipants = MembraneRoom.sharedInstance.$participants
       .sink { _ in
         self.updateVideoTrack()
       }
@@ -35,12 +35,14 @@ class VideoRendererView : UIView {
   
   func updateVideoTrack() {
     DispatchQueue.main.async {
-      let video = MembraneRoom.sharedInstance.participantVideos.first(where: {$0.participant.id == self.participantId})
-      self.videoView?.track = video?.videoTrack
+      let newTrack = MembraneRoom.sharedInstance.getVideoTrackById(trackId: self.trackId)
+      if(newTrack != self.videoView?.track) {
+        self.videoView?.track = newTrack
+      }
     }
   }
   
-  @objc var participantId: String = "" {
+  @objc var trackId: String = "" {
     didSet {
       updateVideoTrack()
     }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -29,8 +29,18 @@ const eventEmitter = new NativeEventEmitter(Membrane);
 export enum ParticipantType {
   Remote = 'Remote',
   Local = 'Local',
-  LocalScreencasting = 'LocalScreencasting',
 }
+
+export enum TrackType {
+  Audio = 'Audio',
+  Video = 'Video',
+}
+
+export type Track = {
+  id: string;
+  type: TrackType;
+  metadata: Metadata;
+};
 
 export type Metadata = { [key: string]: any };
 export type SocketConnectionParams = { [key: string]: any };
@@ -49,13 +59,9 @@ export type Participant = {
    */
   metadata: Metadata;
   /**
-   * a map `string -> any` containing video track metadata from the server
+   * a list of participant's video and audio tracks
    */
-  videoTrackMetadata: Metadata;
-  /**
-   * a map `string -> any` containing audio track metadata from the server
-   */
-  audioTrackMetadata: Metadata;
+  tracks: Track[];
 };
 
 export enum VideoLayout {
@@ -535,12 +541,12 @@ export function useSimulcast() {
    * temporarily unavailable, some other encoding will be sent until choosen encoding
    *  becomes active again.
    *
-   * @param peerId id of a peer whose track encoding you want to select
+   * @param trackId id of a track which encoding you want to select
    * @param encoding encoding to select
    */
   const setTargetTrackEncoding = useCallback(
-    async (peerId: string, encoding: TrackEncoding) => {
-      await Membrane.setTargetTrackEncoding(peerId, encoding);
+    async (trackId: string, encoding: TrackEncoding) => {
+      await Membrane.setTargetTrackEncoding(trackId, encoding);
     },
     []
   );
@@ -603,9 +609,9 @@ export function useBandwidthLimit() {
 
 export type VideoRendererProps = {
   /**
-   * id of the participant which you want to render.
+   * id of the video track which you want to render.
    */
-  participantId: string;
+  trackId: string;
   /**
    * `FILL` or `FIT` - it works just like RN Image component. `FILL` fills the whole view
    * with video and it may cut some parts of the video. `FIT` scales the video so the whole


### PR DESCRIPTION
Now every participant has a list of tracks, so they can have multiple tracks (one participant can have a video track, screencast track and audio track for example).
We're no longer using `{'type': 'screencasting'}` metadata in the sdk (that's up to the user, not sdk)
That also simplified the code a bit.